### PR TITLE
add contributors and note on recurrent contributors

### DIFF
--- a/core_contributors.md
+++ b/core_contributors.md
@@ -8,7 +8,7 @@ Oriol Abril-Pla
 
 [{fab}`github`](https://github.com/oriolabril)
 [{fab}`twitter`](https://twitter.com/OriolAbril)
-[{fas}`globe`](https://oriolabril.github.io/oriol_unraveled)
+[{fas}`globe`](https://oriolabrilpla.cat)
 ::::
 
 ::::{grid-item-card}

--- a/governance/processes.md
+++ b/governance/processes.md
@@ -10,6 +10,14 @@ in the role descriptions. If nominated candidates accept their nomination
 then they can be considered by the Council: on the first of the month following a
 nomination, the Council will vote on each nominee using {ref}`this process <council_voting>`.
 
+:::{note}
+In the case of recurring contributors, the nomination and voting process can be replaced
+by a somewhat similar selection process. Thus, for example, GSoC interns are considered
+recurrent contributors once accepted; similarly, contractors hired thanks
+to grants like CZI EOSS or GSoD ones are also considered recurrent contributors once
+hired.
+:::
+
 Voting will be private with results published on the issue ticket. In the case of a
 rejection, results must include the reasons behind the decision (e.g. the time since
 starting to contribute is deemed too short for now). The candidate

--- a/our_team.md
+++ b/our_team.md
@@ -18,6 +18,9 @@ Those interested in contributing should instead refer to one of our contributing
 
 (recurrent_contributor_list)=
 ## Recurrent contributors
+:::{hlist}
+:columns: 2
+
 * Adrian Seyboldt
 * Andy Maloney
 * Camen Piho
@@ -42,6 +45,7 @@ Those interested in contributing should instead refer to one of our contributing
 * Tomas Capretto
 * Utkarsh Maheshwari
 * Yilin Xia
+:::
 
 (emeritus)=
 ## Emeritus team members

--- a/our_team.md
+++ b/our_team.md
@@ -37,8 +37,11 @@ Those interested in contributing should instead refer to one of our contributing
 * Rishabh Sanjay
 * Rob Zinkov
 * Rosheen Naeem
+* Sarina Chen
+* S I Harini
 * Tomas Capretto
 * Utkarsh Maheshwari
+* Yilin Xia
 
 (emeritus)=
 ## Emeritus team members

--- a/sphinx/custom.css
+++ b/sphinx/custom.css
@@ -2,3 +2,7 @@
   font-size: calc(4rem + 1.5vw) !important;
   line-height: unset !important;
 }
+
+.hlist {
+  width: 100%;
+}


### PR DESCRIPTION
Adding @sarinac and GSoC interns @harini-si and @yilinxia, let us know if you'd like for a different name to appear or to not appear at all. I have also added a note on not needing to "duplicate" the nomination process for gsoc interns or people we hire.

cc @arviz-devs/rv_council 