### PR TITLE
add missing recurrent contributors

### DIFF
--- a/our_team.md
+++ b/our_team.md
@@ -33,16 +33,20 @@ Those interested in contributing should instead refer to one of our contributing
 * Eric Ma
 * Ero Carrera
 * Evdoxia Taka
-* Maxime Kochurov
+* Gayathri Krishnaswamy
+* Jacki Buros
 * Jonathan Lindbloom
 * Junpeng Lao
 * Karin Knudson
+* Maxime Kochurov
 * Marcel Haas
+* Meenal Jhajharia
 * Moritz Freidank
 * Nitish Pasricha
 * Rishabh Sanjay
 * Rob Zinkov
 * Rosheen Naeem
+* Sandra Meneses
 * Sarina Chen
 * S I Harini
 * Tomas Capretto


### PR DESCRIPTION
Forgot to update the list after #21, #22, #23 and #24, this fixes it. Also caught a mistake in the alphabetical order.

<!-- readthedocs-preview arviz-project start -->
----
:books: Documentation preview :books:: https://arviz-project--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview arviz-project end -->